### PR TITLE
Fix duplicate run interval configuration

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -45,7 +45,6 @@ BREAKOUT_PRICE = .0001 # NOT USED YET 1/5/25
 SLEEP_AFTER_CLOSE = 600  # Prevent overtrading
 
 MAX_LOSS_GAIN_CHECK_HOURS = 12  # How far back to check for max loss/gain limits (in hours)
-SLEEP_BETWEEN_RUNS_MINUTES = 15  # How long to sleep between agent runs 🕒
 
 
 # Max Loss/Gain Settings FOR RISK AGENT 1/5/25


### PR DESCRIPTION
## Summary
- remove extra assignment for `SLEEP_BETWEEN_RUNS_MINUTES`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f97abccfc8322b50859009c217d00