### PR TITLE
Fix ezbot imports

### DIFF
--- a/src/ezbot.py
+++ b/src/ezbot.py
@@ -15,8 +15,8 @@ not done yet
 # 7 - liquidation amount
 '''
 
-from ..core.config import *
-from ..core.utils import nice_funcs as n 
+from src.config import *
+from src import nice_funcs as n
 import time
 from termcolor import colored, cprint
 import schedule


### PR DESCRIPTION
## Summary
- import from `src.config` and `src.nice_funcs`

## Testing
- `python -m py_compile src/ezbot.py`

------
https://chatgpt.com/codex/tasks/task_e_683f97a4646083228103169a19df0318