### PR TITLE
Add open interest momentum strategy

### DIFF
--- a/src/strategies/README.md
+++ b/src/strategies/README.md
@@ -10,6 +10,7 @@ strategies/
 ├── custom/              # Directory for your custom strategies
 │   ├── __init__.py
 │   ├── example_strategy.py
+│   ├── open_interest_momentum.py
 │   └── private_my_strategy.py
 └── __init__.py
 ```
@@ -46,9 +47,16 @@ class MyStrategy(BaseStrategy):
             'token': 'TOKEN_ADDRESS',
             'signal': 0.85,        # 85% confidence
             'direction': 'BUY',
-            'metadata': {
-                'reason': 'Strategy-specific reasoning',
-                'indicators': {'rsi': 28, 'trend': 'bullish'}
-            }
+        'metadata': {
+            'reason': 'Strategy-specific reasoning',
+            'indicators': {'rsi': 28, 'trend': 'bullish'}
         }
-``` 
+    }
+```
+
+## Open Interest Momentum Strategy
+This strategy combines spikes in overall open interest with short-term price momentum.
+It uses `MoonDevAPI.get_open_interest()` to track total open interest and `nice_funcs.get_data()`
+for recent price action. If open interest increases more than 1% alongside
+rising prices, it issues a **BUY** signal. If open interest drops more than 1%
+while price falls, it issues a **SELL** signal.

--- a/src/strategies/custom/__init__.py
+++ b/src/strategies/custom/__init__.py
@@ -3,8 +3,9 @@
 """
 from src.strategies.base_strategy import BaseStrategy
 from .example_strategy import ExampleStrategy
+from .open_interest_momentum import OpenInterestMomentumStrategy
 
-__all__ = ['ExampleStrategy']
+__all__ = ['ExampleStrategy', 'OpenInterestMomentumStrategy']
 
 try:  # optional private strategy, ignored if not present
     from .private_my_strategy import MyStrategy

--- a/src/strategies/custom/open_interest_momentum.py
+++ b/src/strategies/custom/open_interest_momentum.py
@@ -1,0 +1,57 @@
+from src.strategies.base_strategy import BaseStrategy
+from src.agents.api import MoonDevAPI
+from src.config import MONITORED_TOKENS
+from src import nice_funcs as n
+import pandas as pd
+from termcolor import cprint
+
+class OpenInterestMomentumStrategy(BaseStrategy):
+    """Combine open interest spikes with short-term price momentum"""
+
+    def __init__(self):
+        super().__init__("Open Interest Momentum 🚀")
+        self.api = MoonDevAPI()
+        self.oi_threshold = 1.0  # percentage change to trigger signal
+
+    def generate_signals(self) -> dict:
+        try:
+            oi_df = self.api.get_open_interest()
+            if oi_df is None or len(oi_df) < 2:
+                cprint("OI data not available", "red")
+                return None
+
+            oi_df['timestamp'] = pd.to_datetime(oi_df['timestamp'])
+            recent = oi_df.iloc[-1]
+            previous = oi_df.iloc[-2]
+            oi_change = ((recent['total_oi'] - previous['total_oi']) / previous['total_oi']) * 100
+
+            token = MONITORED_TOKENS[0]
+            data = n.get_data(token, days_back_4_data=1, timeframe='15m')
+            if data is None or data.empty:
+                return None
+
+            price_change = data['Close'].iloc[-1] - data['Close'].iloc[-5]
+            direction = 'NEUTRAL'
+            signal_strength = 0.0
+
+            if oi_change > self.oi_threshold and price_change > 0:
+                direction = 'BUY'
+                signal_strength = min(abs(oi_change) / 5.0, 1.0)
+            elif oi_change < -self.oi_threshold and price_change < 0:
+                direction = 'SELL'
+                signal_strength = min(abs(oi_change) / 5.0, 1.0)
+            else:
+                return None
+
+            return {
+                'token': token,
+                'signal': round(signal_strength, 2),
+                'direction': direction,
+                'metadata': {
+                    'oi_change_pct': round(oi_change, 2),
+                    'price_change': round(float(price_change), 4)
+                }
+            }
+        except Exception as e:
+            cprint(f"Error generating signals: {e}", "red")
+            return None


### PR DESCRIPTION
## Summary
- add new OpenInterestMomentumStrategy utilizing BaseStrategy
- export new strategy in custom __init__
- document strategy in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f9fab562883229b4162b065843567