### PR TITLE
Add strategist and backtester agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Project updates will be posted in discord, join here: [moondev.com](http://moond
 - Sentiment Agent (`sentiment_agent.py`): analyzes Twitter sentiment for crypto tokens with voice announcements
 - Listing Arbitrage Agent (`listingarb_agent.py`): identifies promising Solana tokens on CoinGecko before they reach major exchanges like Binance and Coinbase, using parallel AI analysis for technical and fundamental insights
 - Focus Agent (`focus_agent.py`): randomly samples audio during coding sessions to maintain productivity, providing focus scores and voice alerts when focus drops (~$10/month, perfect for voice-to-code workflows)
+- Strategist Agent (`strategist_agent.py`): searches online for trending trading ideas and generates new strategy code
+- Backtester Agent (`backtester_agent.py`): runs quick backtests on generated strategies and saves the profitable ones
 
 ## 🚀 Project Progress & Roadmap
 ### Phase 1: Foundation & Basic Trading ✅

--- a/src/agents/backtester_agent.py
+++ b/src/agents/backtester_agent.py
@@ -1,0 +1,79 @@
+"""
+🌙 Moon Dev's Backtester Agent
+Runs a simple backtest on generated strategies and saves them if profitable.
+"""
+
+import os
+import importlib.util
+from datetime import datetime
+from termcolor import cprint
+from dotenv import load_dotenv
+
+from src.config import MONITORED_TOKENS
+from src.strategies.base_strategy import BaseStrategy
+from src import nice_funcs as n
+
+class BacktesterAgent:
+    """Validate strategies using historical data"""
+
+    def __init__(self):
+        load_dotenv()
+
+    def load_strategy(self, code: str):
+        """Load strategy class from code string"""
+        file_name = f"generated_strategy_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.py"
+        path = os.path.join("src", "strategies", "custom", file_name)
+        with open(path, "w") as f:
+            f.write(code)
+        spec = importlib.util.spec_from_file_location("generated_strategy", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore
+        strategy_cls = None
+        for attr in dir(module):
+            obj = getattr(module, attr)
+            if isinstance(obj, type) and issubclass(obj, BaseStrategy) and obj is not BaseStrategy:
+                strategy_cls = obj
+                break
+        return strategy_cls, path
+
+    def backtest(self, strategy: BaseStrategy, days: int = 3):
+        """Very naive backtest using last two candles"""
+        total_return = 0
+        tests = 0
+        for token in MONITORED_TOKENS:
+            df = n.get_data(token, days_back_4_data=days, timeframe="1H")
+            if df is None or df.empty or len(df) < 2:
+                continue
+            signal = strategy.generate_signals()
+            if not signal:
+                continue
+            direction = signal.get("direction")
+            if direction not in ["BUY", "SELL"]:
+                continue
+            entry = df["Close"].iloc[-2]
+            exit_price = df["Close"].iloc[-1]
+            if direction == "BUY":
+                ret = (exit_price - entry) / entry
+            else:
+                ret = (entry - exit_price) / entry
+            total_return += ret
+            tests += 1
+        return (total_return / tests) if tests else 0
+
+    def validate_and_save(self, code: str, threshold: float = 0.0):
+        """Backtest code and keep it if average return above threshold"""
+        strategy_cls, path = self.load_strategy(code)
+        if not strategy_cls:
+            cprint("No valid strategy class found", "red")
+            os.remove(path)
+            return False
+        strategy = strategy_cls()
+        result = self.backtest(strategy)
+        cprint(f"Backtest result: {result*100:.2f}%", "cyan")
+        if result > threshold:
+            cprint(f"Strategy saved to {path}", "green")
+            return True
+        os.remove(path)
+        cprint("Strategy discarded due to poor performance", "yellow")
+        return False
+

--- a/src/agents/strategist_agent.py
+++ b/src/agents/strategist_agent.py
@@ -1,0 +1,89 @@
+"""
+🌙 Moon Dev's Strategist Agent
+Searches the web for trending trading strategy ideas and proposes new strategies
+based on current market conditions.
+"""
+
+import os
+import json
+import requests
+from datetime import datetime
+from termcolor import cprint
+from dotenv import load_dotenv
+import anthropic
+
+from src.config import MONITORED_TOKENS
+from src import nice_funcs as n
+
+# Prompt for strategy generation
+GENERATE_STRATEGY_PROMPT = """
+You are Moon Dev's Strategist AI 🌙
+
+Trending Strategy Ideas:
+{ideas}
+
+Current Market Snapshot:
+{market_data}
+
+Using these ideas and market conditions, write a new trading strategy in Python.
+The strategy must inherit from `BaseStrategy` and implement `generate_signals()`.
+Respond ONLY with the Python code for the strategy.
+"""
+
+class StrategistAgent:
+    """Agent that searches the web and creates strategy code"""
+
+    def __init__(self):
+        load_dotenv()
+        api_key = os.getenv("ANTHROPIC_KEY")
+        if not api_key:
+            raise ValueError("ANTHROPIC_KEY missing")
+        self.client = anthropic.Anthropic(api_key=api_key)
+
+    def search_trending_strategies(self, limit: int = 5):
+        """Fetch recent strategy discussions from Reddit"""
+        try:
+            url = f"https://www.reddit.com/r/algotrading/new.json?limit={limit}"
+            headers = {"User-Agent": "Mozilla/5.0"}
+            resp = requests.get(url, headers=headers, timeout=10)
+            if resp.status_code == 200:
+                data = resp.json()
+                titles = [child["data"]["title"] for child in data["data"]["children"]]
+                return titles
+        except Exception as e:
+            cprint(f"Error fetching reddit ideas: {e}", "red")
+        return []
+
+    def get_market_snapshot(self):
+        """Collect simple market data for monitored tokens"""
+        snapshot = {}
+        for token in MONITORED_TOKENS:
+            df = n.get_data(token, days_back_4_data=1, timeframe="1H")
+            if df is None or df.empty:
+                continue
+            snapshot[token] = {
+                "last_close": df["Close"].iloc[-1],
+                "ma20": df["MA20"].iloc[-1],
+                "rsi": df["RSI"].iloc[-1],
+            }
+        return snapshot
+
+    def create_strategy(self):
+        """Generate new strategy code using an LLM"""
+        ideas = self.search_trending_strategies()
+        market_data = self.get_market_snapshot()
+        prompt = GENERATE_STRATEGY_PROMPT.format(
+            ideas=json.dumps(ideas, indent=2),
+            market_data=json.dumps(market_data, indent=2)
+        )
+        message = self.client.messages.create(
+            model=os.getenv("AI_MODEL", "claude-3-haiku-20240307"),
+            max_tokens=800,
+            temperature=0.7,
+            messages=[{"role": "user", "content": prompt}]
+        )
+        response = message.content
+        if isinstance(response, list):
+            response = response[0].text if hasattr(response[0], "text") else str(response[0])
+        return response
+


### PR DESCRIPTION
## Summary
- add a strategist agent that searches Reddit for trading ideas and generates new strategy code
- add a backtester agent that runs a quick historical check on generated strategies
- document the two new agents in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683faab42c688322a91084cd2b892d91